### PR TITLE
removed overlay from dashboard tile (which has also just been removed…

### DIFF
--- a/src/main/java/org/openhab/ui/habmin/internal/HABminUIDashboardTile.java
+++ b/src/main/java/org/openhab/ui/habmin/internal/HABminUIDashboardTile.java
@@ -35,6 +35,6 @@ public class HABminUIDashboardTile implements DashboardTile {
 
     @Override
     public String getOverlay() {
-        return "html5";
+        return null;
     }
 }


### PR DESCRIPTION
… on all other UIs)

Signed-off-by: Kai Kreuzer <kai@openhab.org>