### PR TITLE
Don't reset authorization header if no auth data is stored

### DIFF
--- a/src/web/app/models/userModel.js
+++ b/src/web/app/models/userModel.js
@@ -38,7 +38,7 @@ angular.module('HABmin.userModel', [
 
             authenticated = true;
         }
-        else {
+        else if (storedTime != null) {
             console.log("Removing saved authentication data!");
             // Timeout - remove the password etc.
             localStorage.removeItem('Auth-pass');


### PR DESCRIPTION
Habmin resets the Authorization header when clearing stale saved auth info, but does so even if no auth info was saved (e.g., when using nginx for authentication instead). This is the cause of #220.

This change only clears the auth header when stale saved data is actually being cleared as well.