### PR TITLE
Add scm connection info to pom.xml

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -23,6 +23,12 @@
         <report.fail.on.error>false</report.fail.on.error>
     </properties>
 
+    <scm>
+        <connection>scm:git:${scm.gitBaseUrl}/org.openhab.ui.habmin.git</connection>
+        <developerConnection>scm:git:${scm.gitBaseUrl}/org.openhab.ui.habmin.git</developerConnection>
+        <url>https://github.com/openhab/org.openhab.ui.habmin</url>
+    </scm>
+
     <build>
         <plugins>
             <plugin>


### PR DESCRIPTION
_This is a cross-repo change which is part of the implementation of a release automation process for openHAB_

This adds scm connection info to the pom.xml which is used by release automation processes to push changes, create tags etc. The property `scm.gitBaseUrl` is taken from the parent pom within the openhab-core component https://github.com/openhab/openhab-core/blob/a1e10ccea71189991fb542e4251ac8bee04c4c91/poms/pom.xml#L51 and makes it possible to easily make "sandbox releases" on separate repositories. Within the `url` tag, the `scm.gitBaseUrl` is intentionally not used because in discussions with @kaikreuzer I agreed that we aim to keep the pom.xml human-readable without always having to lookup properties from the parent pom(s). As the `url` tag is just a meta information and not used by any automation process, it's no problem to hard-code the production repo there.

Signed-off-by: Patrick Fink <mail@pfink.de>